### PR TITLE
/system/identity set/get

### DIFF
--- a/.github/scripts/setup_routeros.py
+++ b/.github/scripts/setup_routeros.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import routeros_api
 import os
 

--- a/client/system_identity.go
+++ b/client/system_identity.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type SystemIdentity struct {
+	ID   string `json:".id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+func (c *Client) CreateSystemIdentity(system_identity *SystemIdentity) (*SystemIdentity, error) {
+	reqBody, err := json.Marshal(system_identity)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/rest/system/identity/set", c.HostURL), bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, err
+	}
+
+    var res interface{}
+	if c.sendRequest(req, &res); err != nil {
+		return nil, err
+	}
+
+    return c.ReadSystemIdentity()
+}
+
+func (c *Client) ReadSystemIdentity() (*SystemIdentity, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/rest/system/identity", c.HostURL), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res := SystemIdentity{}
+	if c.sendRequest(req, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+func (c *Client) UpdateSystemIdentity(system_identity *SystemIdentity) (*SystemIdentity, error) {
+	reqBody, err := json.Marshal(system_identity)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/rest/system/identity/set", c.HostURL), bytes.NewBuffer(reqBody))
+	if err != nil {
+		return nil, err
+	}
+
+    var res interface{}
+	if c.sendRequest(req, &res); err != nil {
+		return nil, err
+	}
+
+    return c.ReadSystemIdentity()
+}
+
+func (c *Client) DeleteSystemIdentity(system_identity *SystemIdentity) error {
+    default_system_identity := new(SystemIdentity)
+    default_system_identity.Name = "MikroTik"
+
+    reqBody, err := json.Marshal(default_system_identity)
+    if err != nil {
+        return err
+    }
+
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/rest/system/identity/set", c.HostURL), bytes.NewBuffer(reqBody))
+	if err != nil {
+		return err
+	}
+
+    var res interface{}
+	if err := c.sendRequest(req, &res); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/system_identity_test.go
+++ b/client/system_identity_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func CreateSystemIdentityTestObjects() (*SystemIdentity, error) {
+	c := NewClient(GetCredentialsFromEnvVar())
+	system_identity := new(SystemIdentity)
+	system_identity.Name = "myself"
+	res, err := c.CreateSystemIdentity(system_identity)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func TestCreateSystemIdentity(t *testing.T) {
+	c := NewClient(GetCredentialsFromEnvVar())
+	system_identity := new(SystemIdentity)
+	system_identity.Name = "myself"
+	res, err := c.CreateSystemIdentity(system_identity)
+	assert.Nil(t, err, "expecting a nil error")
+	assert.NotNil(t, res, "expecting a non-nil result")
+	assert.NotNil(t, res.ID, "expecting result to have an id")
+	assert.Equal(t, system_identity.Name, res.Name)
+	err = c.DeleteSystemIdentity(res)
+	assert.Nil(t, err, "expecting a nil error on delete")
+}
+
+func TestReadSystemIdentity(t *testing.T) {
+	c := NewClient(GetCredentialsFromEnvVar())
+
+	system_identity, err := CreateSystemIdentityTestObjects()
+	assert.Nil(t, err, "expecting a nil error")
+
+	res, err := c.ReadSystemIdentity()
+	assert.Nil(t, err, "expecting a nil error")
+	assert.Equal(t, res.ID, system_identity.ID)
+	assert.Equal(t, system_identity.Name, res.Name)
+
+	err = c.DeleteSystemIdentity(res)
+	assert.Nil(t, err, "expecting a nil error on delete")
+}
+
+func TestUpdateSystemIdentity(t *testing.T) {
+	c := NewClient(GetCredentialsFromEnvVar())
+
+	new_system_identity := SystemIdentity{}
+	new_system_identity.Name = "yourself"
+
+	res, err := c.UpdateSystemIdentity(&new_system_identity)
+	assert.Nil(t, err, "expecting a nil error")
+	assert.Equal(t, res.Name, new_system_identity.Name)
+
+	err = c.DeleteSystemIdentity(res)
+	assert.Nil(t, err, "expecting a nil error on delete")
+}

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -52,6 +52,7 @@ func Provider() *schema.Provider {
 			"routeros_interface_bridge":         resourceInterfaceBridge(),
 			"routeros_interface_wireguard":      resourceInterfaceWireguard(),
 			"routeros_interface_wireguard_peer": resourceInterfaceWireguardPeer(),
+			"routeros_system_identity":          resourceSystemIdentity(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_ip_addresses": datasourceIPAddresses(),

--- a/routeros/resource_system_identity.go
+++ b/routeros/resource_system_identity.go
@@ -1,0 +1,97 @@
+package routeros
+
+import (
+	"log"
+
+	roscl "github.com/gnewbury1/terraform-provider-routeros/client"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceSystemIdentity() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSystemIdentityCreate,
+		Read:   resourceSystemIdentityRead,
+		Update: resourceSystemIdentityUpdate,
+		Delete: resourceSystemIdentityDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceSystemIdentityCreate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*roscl.Client)
+
+	system_identity := new(roscl.SystemIdentity)
+	system_identity.Name = d.Get("name").(string)
+
+	res, err := c.CreateSystemIdentity(system_identity)
+	if err != nil {
+		log.Println("[ERROR] An error was encountered while sending a PUT request to the API")
+		log.Fatal(err.Error())
+		return err
+	}
+
+	d.SetId(res.Name)
+	return nil
+}
+
+func resourceSystemIdentityRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*roscl.Client)
+	system_identity, err := c.ReadSystemIdentity()
+
+	if err != nil {
+		log.Println("[ERROR] An error was encountered while sending a GET request to the API")
+		log.Fatal(err.Error())
+		return err
+	}
+
+	d.SetId(system_identity.Name)
+	d.Set("name", system_identity.Name)
+
+	return nil
+}
+
+func resourceSystemIdentityUpdate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*roscl.Client)
+
+	system_identity := new(roscl.SystemIdentity)
+	system_identity.Name = d.Get("name").(string)
+
+	res, err := c.UpdateSystemIdentity(system_identity)
+
+	if err != nil {
+		log.Println("[ERROR] An error was encountered while sending a PATCH request to the API")
+		log.Fatal(err.Error())
+		return err
+	}
+
+	d.SetId(res.Name)
+
+	return nil
+}
+
+func resourceSystemIdentityDelete(d *schema.ResourceData, m interface{}) error {
+	c := m.(*roscl.Client)
+
+	system_identity, _ := c.ReadSystemIdentity()
+	err := c.DeleteSystemIdentity(system_identity)
+
+	if err != nil {
+		log.Println("[ERROR] An error was encountered while sending a DELETE request to the API")
+		log.Fatal(err.Error())
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/routeros/resource_system_identity_test.go
+++ b/routeros/resource_system_identity_test.go
@@ -1,0 +1,90 @@
+package routeros
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gnewbury1/terraform-provider-routeros/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const testSystemIdentityName = "routeros_system_identity.myself"
+
+func TestAccSystemIdentityTest_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSystemIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemIdentityConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSystemIdentityExists(testSystemIdentityName),
+					resource.TestCheckResourceAttr(testSystemIdentityName, "name", "myself"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSystemIdentityExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no id is set")
+		}
+
+		return nil
+	}
+}
+
+func testAccSystemIdentityConfig() string {
+	return `
+
+provider "routeros" {
+  insecure = true
+}
+
+resource "routeros_system_identity" "myself" {
+  name   = "myself"
+}
+
+`
+}
+
+func testAccCheckSystemIdentityDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*client.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "routeros_system_identity" {
+			continue
+		}
+		id := rs.Primary.ID
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/ip/pool/%s", c.HostURL, id), nil)
+		if err != nil {
+			return err
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.SetBasicAuth(c.Username, c.Password)
+
+		res, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil
+		}
+
+		if res.StatusCode != 404 {
+			return fmt.Errorf("dhcp client %s has been found", id)
+		}
+
+		return nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
Because we cannot 'delete' a System Identity we just reset it back to the default `MikroTik`. If that's not the best idea, we can instead just make the delete a 'no op' and skip it.

Closes #55 