### PR TITLE
fix: pvid defaults to 1

### DIFF
--- a/routeros/resource_interface_bridge.go
+++ b/routeros/resource_interface_bridge.go
@@ -126,7 +126,7 @@ func resourceInterfaceBridge() *schema.Resource {
 			"pvid": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  0,
+				Default:  1,
 			},
 			"running": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
According to [offcial docs](https://help.mikrotik.com/docs/display/ROS/Bridging+and+Switching) pvid should be within range of 1 to 4094 defaulting to 1
Fixes: #73