### PR TITLE
Removed the computed fields from create and update 

### DIFF
--- a/docs/resources/ip_address.md
+++ b/docs/resources/ip_address.md
@@ -11,9 +11,9 @@ description: |-
 
 ```terraform
 resource "routeros_ip_address" "address" {
-  address   = "10.0.0.1"
+  address   = "10.0.0.1/24"
   interface = "bridge"
-  network   = "10.0.0.0/24"
+  network   = "10.0.0.0"
 }
 ```
 

--- a/routeros/resource_ip_address.go
+++ b/routeros/resource_ip_address.go
@@ -62,8 +62,6 @@ func resourceIPAddressCreate(d *schema.ResourceData, m interface{}) error {
 	ip_addr.Disabled = strconv.FormatBool(d.Get("disabled").(bool))
 	ip_addr.Interface = d.Get("interface").(string)
 	ip_addr.Network = d.Get("network").(string)
-	ip_addr.ActualInterface = d.Get("actual_interface").(string)
-	//ip_addr.Invalid = strconv.FormatBool(d.Get("invalid").(bool))
 
 	res, err := c.CreateIPAddress(ip_addr)
 	if err != nil {
@@ -125,8 +123,6 @@ func resourceIPAddressUpdate(d *schema.ResourceData, m interface{}) error {
 	ip_addr.Disabled = strconv.FormatBool(d.Get("disabled").(bool))
 	ip_addr.Interface = d.Get("interface").(string)
 	ip_addr.Network = d.Get("network").(string)
-	ip_addr.ActualInterface = d.Get("actual_interface").(string)
-	ip_addr.Invalid = strconv.FormatBool(d.Get("invalid").(bool))
 
 	res, err := c.UpdateIPAddress(d.Id(), ip_addr)
 

--- a/routeros/resource_ip_address.go
+++ b/routeros/resource_ip_address.go
@@ -63,7 +63,7 @@ func resourceIPAddressCreate(d *schema.ResourceData, m interface{}) error {
 	ip_addr.Interface = d.Get("interface").(string)
 	ip_addr.Network = d.Get("network").(string)
 	ip_addr.ActualInterface = d.Get("actual_interface").(string)
-	ip_addr.Invalid = strconv.FormatBool(d.Get("invalid").(bool))
+	//ip_addr.Invalid = strconv.FormatBool(d.Get("invalid").(bool))
 
 	res, err := c.CreateIPAddress(ip_addr)
 	if err != nil {


### PR DESCRIPTION
Removed the computed fields (actual_interface and invalid) for the Create and Update functions.  On ROS7.6 it was rejecting the REST payload.
